### PR TITLE
needs fixing

### DIFF
--- a/scripts/3_visualize/visualizeLandUse.R
+++ b/scripts/3_visualize/visualizeLandUse.R
@@ -26,13 +26,19 @@ visualizeLandUse <- function(tag, fname.geom.conc, fname.geom.pct, fname.fig){
 # Returns gsplot object for the top part of the figure
 gsplotLandUseConc <- function(fname.data){
   
-  geom.df <-  read.table(fname.data, sep = "\t")
-
+  geom.df <-  read.table(fname.data, sep = "\t", stringsAsFactors = FALSE)
+  sites <- unique(geom.df$site.name)
+  site.ids <- data.frame('site.name'=sites, num=1:length(sites), stringsAsFactors = FALSE)
+  geom.df <- left_join(geom.df, site.ids) %>% 
+    mutate(id = paste0(num,'-',type))
   gs.conc <- gsplot() %>% 
     rect(geom.df$x.left, geom.df$y.bottom, 
          geom.df$x.right, geom.df$y.top,
-         lwd=0.5, col = geom.df$rect.col, 
-         legend.name=levels(geom.df$type))
+         lwd=0.5, col = geom.df$rect.col) %>% 
+    axis(side = 2, at = seq(0, 10, by=5)) %>% 
+    axis(1, labels=FALSE)
+  # hack because we need to support gs extensions
+  gs.conc$view.1.2$rect$id=geom.df$id
   return(gs.conc)
 }
 
@@ -55,7 +61,7 @@ gsplotLandUsePct <- function(fname.data){
 
 
 createBarFig <- function(gs.conc, gs.landuse, target_name){
-  gs.landuse$global$par$mar <- c(9.1, 4.1, 13.1, 2.1)
+  gs.landuse$global$par$mar <- c(9.1, 4.1, 13.5, 2.1)
   svg <- dinosvg::svg(gs.landuse, width = 6, height = 6.3, as.xml=TRUE)
   view.1 <- dinosvg:::g_view(svg, side=c(1,2))
   attrs <- XML:::xmlAttrs(view.1)

--- a/scripts/3_visualize/visualizeLandUse.R
+++ b/scripts/3_visualize/visualizeLandUse.R
@@ -74,11 +74,7 @@ visualizeLandUse <- function(fname.data, fname.fig){
     rect(position.df.conc$x.left, position.df.conc$y.bottom, 
          position.df.conc$x.right, position.df.conc$y.top,
          lwd=0.5, col = position.df.conc$rect.col, 
-         legend.name=levels(position.df.conc$type)) %>% 
-    axis(side = 1, at = at, 
-         labels = labels, 
-         tick = FALSE, las = 2, cex.axis = 0.1) %>% 
-    axis(side = 2, at = seq(0, 10, by=5))
+         legend.name=levels(position.df.conc$type), side=c(3,2)) # hack because can't be side 4
   
 ## ----------- ## landuse barplot ## ----------- ##
   
@@ -128,3 +124,13 @@ visualizeLandUse <- function(fname.data, fname.fig){
   saveRDS(gs_landuse, file = "cache/visualize_land_use.RDS")
 }
 
+
+createBarFig <- function(file.conc, file.landuse, target_name){
+  gs.conc <- readRDS(file.conc)
+  gs.landuse <- readRDS(file.landuse)
+  gs.landuse$global$par$mar <- c(9.1, 4.1, 13.1, 2.1)
+  svg <- dinosvg::svg(gs.landuse, width = 6, height = 6.3, as.xml=TRUE)
+  
+  gs.conc$global$par$mar <- c(19.1, 4.1, 2.1, 2.1)
+  dinosvg::svg(svg, gs.conc)
+}

--- a/scripts/3_visualize/visualizeLandUse.R
+++ b/scripts/3_visualize/visualizeLandUse.R
@@ -2,14 +2,14 @@
 #' @import dinosvg
 
 # Functions directly called by remake:make('figures_R.yaml')
-visualizeRelativeAbundance_mobile <- function(...) {
-  visualizeRelativeAbundance('mobile', ...)
+visualizeLandUse_mobile <- function(data.conc, data.landuse, file.out) {
+  visualizeLandUse('mobile', data.conc, data.landuse, file.out)
 }
-visualizeRelativeAbundance_desktop <- function(...) {
-  visualizeRelativeAbundance('desktop', ...)
+visualizeLandUse_desktop <- function(data.conc, data.landuse, file.out) {
+  visualizeLandUse('desktop', data.conc, data.landuse, file.out)
 }
-visualizeRelativeAbundance_ie <- function(...) {
-  visualizeRelativeAbundance('ie', ...)
+visualizeLandUse_ie <- function(data.conc, data.landuse, file.out) {
+  visualizeLandUse('ie', data.conc, data.landuse, file.out)
 }
 
 # The workhorse function
@@ -33,11 +33,7 @@ gsplotLandUseConc <- function(fname.data){
     rect(geom.df$x.left, geom.df$y.bottom, 
          geom.df$x.right, geom.df$y.top,
          lwd=0.5, col = geom.df$rect.col, 
-         legend.name=levels(geom.df$type)) %>% 
-    axis(side = 1, at = geom.df$x.middle, 
-         labels = geom.df$site.name, 
-         tick = FALSE, las = 2, cex.axis = 0.1) %>% 
-    axis(side = 2, at = seq(0, 10, by=5))
+         legend.name=levels(geom.df$type), side=c(3))
   return(gs.conc)
 }
 

--- a/scripts/3_visualize/visualizeLandUse.R
+++ b/scripts/3_visualize/visualizeLandUse.R
@@ -32,7 +32,7 @@ gsplotLandUseConc <- function(fname.data){
     rect(geom.df$x.left, geom.df$y.bottom, 
          geom.df$x.right, geom.df$y.top,
          lwd=0.5, col = geom.df$rect.col, 
-         legend.name=levels(geom.df$type), side=c(3, 2))
+         legend.name=levels(geom.df$type))
   return(gs.conc)
 }
 
@@ -57,7 +57,12 @@ gsplotLandUsePct <- function(fname.data){
 createBarFig <- function(gs.conc, gs.landuse, target_name){
   gs.landuse$global$par$mar <- c(9.1, 4.1, 13.1, 2.1)
   svg <- dinosvg::svg(gs.landuse, width = 6, height = 6.3, as.xml=TRUE)
+  view.1 <- dinosvg:::g_view(svg, side=c(1,2))
+  attrs <- XML:::xmlAttrs(view.1)
+  
+  XML:::removeAttributes(view.1)
+  XML:::addAttributes(view.1, .attrs = c(id='view-1-2a')) # renaming the view as a hack...
   
   gs.conc$global$par$mar <- c(19.1, 4.1, 2.1, 2.1)
-  dinosvg::svg(svg, gs.conc)
+  dinosvg::svg(svg, gs.conc, file=target_name)
 }

--- a/scripts/3_visualize/visualizeLandUse.R
+++ b/scripts/3_visualize/visualizeLandUse.R
@@ -68,13 +68,15 @@ visualizeLandUse <- function(fname.data, fname.fig){
                              meanFilm = "yellow",
                              meanFoam = "blue"))
 
-  gs.conc <- gsplot() %>% 
+  at <- unique(position.df.conc$x.middle)
+  labels <- unique(position.df.conc$site.name)
+  gs_conc <- gsplot() %>% 
     rect(position.df.conc$x.left, position.df.conc$y.bottom, 
          position.df.conc$x.right, position.df.conc$y.top,
          lwd=0.5, col = position.df.conc$rect.col, 
          legend.name=levels(position.df.conc$type)) %>% 
-    axis(side = 1, at = position.df.conc$x.middle, 
-         labels = position.df.conc$site.name, 
+    axis(side = 1, at = at, 
+         labels = labels, 
          tick = FALSE, las = 2, cex.axis = 0.1) %>% 
     axis(side = 2, at = seq(0, 10, by=5))
   
@@ -109,13 +111,14 @@ visualizeLandUse <- function(fname.data, fname.fig){
                              UrbanPct = "salmon",
                              AgTotalPct = "yellow",
                              OtherPct = "lightgreen"))
-  
+  at <- unique(position.df.landuse$x.middle)
+  labels <- unique(position.df.landuse$site.name)
   gs_landuse <- gsplot() %>% 
     rect(position.df.landuse$x.left, position.df.landuse$y.bottom, 
          position.df.landuse$x.right, position.df.landuse$y.top,
          lwd=0.5, col = position.df.landuse$rect.col) %>% 
-    axis(side = 1, at = position.df.landuse$x.middle, 
-         labels = position.df.landuse$site.name, 
+    axis(side = 1, at = at,
+         labels = labels, 
          tick = FALSE, las = 2, cex.axis = 0.1) %>% 
     axis(side = 2, at = seq(0, 100, by=25))
   

--- a/scripts/3_visualize/visualizeLandUse.R
+++ b/scripts/3_visualize/visualizeLandUse.R
@@ -20,7 +20,6 @@ visualizeLandUse <- function(tag, fname.geom.conc, fname.geom.pct, fname.fig){
   gs.landuse <- gsplotLandUsePct(fname.geom.pct)
   
   createBarFig(gs.conc, gs.landuse, fname.fig)
-  ############## SVG MAGIC HAPPENS HERE ############## 
 
 }
 


### PR DESCRIPTION
@lindsaycarr can you make the change to the name of the `conc` gsplot object, and then make the axis call to side 1 only create one label per site? Right now it creates one for each box (3 or 5) and overplots those. 

My fix for the labels and at is a hack, but it points out the issue. 
