### PR TITLE
Citations

### DIFF
--- a/data/siteText.yaml
+++ b/data/siteText.yaml
@@ -66,25 +66,25 @@ envEffects-p2: >-
 
 ## Environmental Effects Facts## 
 envEffects-globalProd1: ">617,000,000,000"
-envEffects-globalProd2: pounds of plastic produced worldwide in 2012
+envEffects-globalProd2: "pounds of plastic produced worldwide in 2012"
 
 envEffects-fish1: Particles found in
 envEffects-fish2: 12%
-envEffects-fish3: of <strong>freshwater fish</strong>
+envEffects-fish3: "of <strong>freshwater fish</strong><sup><a href='#ref1'>1</a></sup>"
 
 envEffects-oysters1: 50
 envEffects-oysters2: particles per serving of  commercially-cultured <strong>oysters</strong>
 envEffects-oysters3: 90
-envEffects-oysters4: particles per serving of  commercially-cultured <strong>mussels</strong> 
+envEffects-oysters4: "particles per serving of  commercially-cultured <strong>mussels</strong><sup><a href='#ref2'>2</a></sup>"
 
 envEffects-stream1: Up to 
 envEffects-stream2: 32
 envEffects-stream3: particles per cubic meter of Great Lakes tributary <strong>water</strong>
 envEffects-stream4: ">13,800"
-envEffects-stream5: particles per square meter of river <strong>sediment</strong>
+envEffects-stream5: "particles per square meter of river <strong>sediment</strong><sup><a href='#ref3'>3</a></sup>"
 
 envEffects-lake1: "43,000" 
-envEffects-lake2: particles per square kilometer of Great Lakes <strong>water</strong>
+envEffects-lake2: "particles per square kilometer of Great Lakes <strong>water</strong><sup><a href='#ref4'>4</a></sup>"
 
 ## Land Use Correlation ##
 landUse-intro: How do microplastics get into our rivers and streams?
@@ -105,27 +105,27 @@ footerContact: owi.webmaster@usgs.gov
 ## Supplemental Information ##
 
 ref1: >- 
-  Eriksen, M.; Mason, S.; Wilson, S.; Box, C.; Zellers, A.; Edwards, W.; Farley, H.; Amato, S. 
-  Microplastic pollution in the surface waters of the Laurentian Great Lakes. 
-  Mar. Pollut. Bull. 2013, 77 (1-2)
-  <a href='http://dx.doi.org/10.1016/j.marpolbul.2016.03.041' target='_blank'>10.1016/j.marpolbul.2016.03.041</a>
-  
+  Sanchez W, Bender C, Porcher JM. 
+  Wild gudgeons (Gobio gobio) from French rivers are contaminated by microplastics: preliminary study and first evidence. 
+  Environmental research. 2014 Jan 31;128:98-100
+  <a href='http://dx.doi.org/10.1186/s12302-014-0012-7' target='_blank'>10.1186/s12302-014-0012-7</a>
+
 ref2: >- 
   Van Cauwenberghe L, Janssen CR. 
   Microplastics in bivalves cultured for human consumption. 
   Environmental Pollution. 2014 Oct 31;193:65-70
   <a href='http://dx.doi.org/10.1016/j.envpol.2014.06.010' target='_blank'>10.1016/j.envpol.2014.06.010</a>
-  
-  
-ref3: >- 
-  Sanchez W, Bender C, Porcher JM. 
-  Wild gudgeons (Gobio gobio) from French rivers are contaminated by microplastics: preliminary study and first evidence. 
-  Environmental research. 2014 Jan 31;128:98-100
-  <a href='http://dx.doi.org/10.1186/s12302-014-0012-7' target='_blank'>10.1186/s12302-014-0012-7</a>
-  
-ref4: >-
+
+ref3: >-
   Baldwin, A.; Corsi, S.; Mason, S. 
   Microplastics in 29 Great Lakes tributaries: Relations to watershed attributes and hydrology. 2016.
+
+ref4: >- 
+  Eriksen, M.; Mason, S.; Wilson, S.; Box, C.; Zellers, A.; Edwards, W.; Farley, H.; Amato, S. 
+  Microplastic pollution in the surface waters of the Laurentian Great Lakes. 
+  Mar. Pollut. Bull. 2013, 77 (1-2)
+  <a href='http://dx.doi.org/10.1016/j.marpolbul.2016.03.041' target='_blank'>10.1016/j.marpolbul.2016.03.041</a>
+
   
 ref5: >-
   Rochman, C.M., Browne, M.A., Halpern, B.S., Hentschel, B.T., Hoh, E., Karapanagioti, H.K., Rios-Mendoza, L.M., Takada, H., Teh, S. and Thompson, R.C., 2013. 

--- a/data/siteText.yaml
+++ b/data/siteText.yaml
@@ -108,19 +108,20 @@ ref1: >-
   Eriksen, M.; Mason, S.; Wilson, S.; Box, C.; Zellers, A.; Edwards, W.; Farley, H.; Amato, S. 
   Microplastic pollution in the surface waters of the Laurentian Great Lakes. 
   Mar. Pollut. Bull. 2013, 77 (1-2)
-  http://dx.doi.org/10.1016/j.marpolbul.2016.03.041
+  <a href='http://dx.doi.org/10.1016/j.marpolbul.2016.03.041' target='_blank'>10.1016/j.marpolbul.2016.03.041</a>
   
 ref2: >- 
   Van Cauwenberghe L, Janssen CR. 
   Microplastics in bivalves cultured for human consumption. 
   Environmental Pollution. 2014 Oct 31;193:65-70
-  http://dx.doi.org/10.1016/j.envpol.2014.06.010
+  <a href='http://dx.doi.org/10.1016/j.envpol.2014.06.010' target='_blank'>10.1016/j.envpol.2014.06.010</a>
+  
   
 ref3: >- 
   Sanchez W, Bender C, Porcher JM. 
   Wild gudgeons (Gobio gobio) from French rivers are contaminated by microplastics: preliminary study and first evidence. 
   Environmental research. 2014 Jan 31;128:98-100
-  http://dx.doi.org/10.1186/s12302-014-0012-7
+  <a href='http://dx.doi.org/10.1186/s12302-014-0012-7' target='_blank'>10.1186/s12302-014-0012-7</a>
   
 ref4: >-
   Baldwin, A.; Corsi, S.; Mason, S. 
@@ -129,6 +130,7 @@ ref4: >-
 ref5: >-
   Rochman, C.M., Browne, M.A., Halpern, B.S., Hentschel, B.T., Hoh, E., Karapanagioti, H.K., Rios-Mendoza, L.M., Takada, H., Teh, S. and Thompson, R.C., 2013. 
   Policy: Classify plastic waste as hazardous. 
-  http://dx.doi.org/10.1038/494169a
+  <a href='http://dx.doi.org/10.1038/494169a' target='_blank'>10.1038/494169a</a>
+  
   
   

--- a/layout/templates/reference.mustache
+++ b/layout/templates/reference.mustache
@@ -6,19 +6,19 @@
 		</div>
 		<div id="referencePanels">
 			<div class="panel">
-				<p>{{{ref1}}}</p>
+			  <p><a name="ref1">{{{ref1}}}</a></p>
 			</div>
 			<div class="panel">
-				<p>{{{ref2}}}</p>
+				<p><a name="ref2">{{{ref2}}}</a></p>
 			</div>
 			<div class="panel">
-				<p>{{{ref3}}}</p>
+				<p><a name="ref3">{{{ref3}}}</a></p>
 			</div>
 			<div class="panel">
-				<p>{{{ref4}}}</p>
+				<p><a name="ref4">{{{ref4}}}</a></p>
 			</div>
 			<div class="panel">
-				<p>{{{ref5}}}</p>
+				<p><a name="ref5">{{{ref5}}}</a></p>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
@mwernimont I tried to put links to the list of references. If the Reference table is open (ie.the user clicked it to show all), then the links work. But, as a default, they don't go anywhere. Could we either have that References section open by default...or could you do javascript magic to have a click first open up that table and then go to the correct reference?
